### PR TITLE
feature/mini_magick導入

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:3.3.0
 # 必要なパッケージをインストール
 RUN apt-get update -qq && apt-get install -y nodejs npm mariadb-client
 
+RUN apt-get update && apt-get install -y libvips
 # 作業ディレクトリを指定
 WORKDIR /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+gem 'image_processing', '~> 1.2'
+gem 'mini_magick', '~> 4.0'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,10 +103,14 @@ GEM
       reline (>= 0.3.8)
     drb (2.2.1)
     erubi (1.13.1)
+    ffi (1.17.1-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.1.0)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -133,6 +137,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -147,21 +152,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.6-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.6-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.6-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.6-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.6-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.18.6-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.18.6-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.6-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.3)
@@ -252,6 +243,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.3)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.30.1)
@@ -296,15 +290,7 @@ GEM
     zeitwerk (2.7.2)
 
 PLATFORMS
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
-  arm64-darwin
-  x86_64-darwin
-  x86_64-linux
   x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
@@ -312,8 +298,10 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  mini_magick (~> 4.0)
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
@@ -326,4 +314,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.5.3
+   2.6.6

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -15,10 +15,12 @@ class ImagesController < ApplicationController
   def create
     @image = current_user.images.build(image_params)
     if @image.save
+      resized_image = @image.photo.variant(resize_to_limit: [1920, 1080]).processed
+      @image.photo.attach(io: StringIO.new(resized_image.download), filename: @image.photo.filename.to_s, content_type: @image.photo.content_type)
       redirect_to root_path, notice: "写真が投稿されました！"
     else
-      logger.error "Image save failed: #{@image.errors.full_messages.join(", ")}"
-      redirect_to root_path, alert: "写真の投稿に失敗しました。"
+      flash.now[:alert] = @image.errors.full_messages.join(", ")
+      redirect_to new_image_path, alert: @image.errors.full_messages.join(", ")
     end
   end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -4,7 +4,18 @@ class Image < ApplicationRecord
   has_many :image_types, through: :image_categorizations
 
   has_one_attached :photo
+  validate :validate_image_size
 
   validates :title, presence: true
   validates :photo, presence: true
+
+  private
+
+  def validate_image_size
+    return unless photo.attached?
+
+    if photo.byte_size > 10.megabytes
+      errors.add(:photo, "ファイルサイズは10MBを超えることができません。")
+    end
+  end
 end

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -1,3 +1,8 @@
+<% if flash[:alert] %>
+  <div class="alert alert-danger">
+    <%= flash[:alert] %>
+  </div>
+<% end %>
 <%= form_with(model: image, url: images_path, local: true) do |form| %>
   <div class="container mt-4">
     <div class="row justify-content-center">

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,6 @@ module SceneryApp
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
-    config.middleware.use Rack::CommonLogger, max_file_size: 10.megabytes
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,2 @@
+Rails.application.config.active_storage.service_urls_expire_in = 5.minutes
+Rails.application.config.active_storage.max_file_size = 50.megabytes


### PR DESCRIPTION
gem 'image_processing', '~> 1.2'
gem 'mini_magick', '~> 4.0'
を追加
　10MB以上のファイルを受け付けないでコストを下げるため、
　フルHDへのリサイズでサーバー使用コストを下げるために導入
　
